### PR TITLE
fix: align README/docs conflict contract with runtime behavior (Issue #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ ls -la ~/.claude/rules   # → mantra/rules へのシムリンク
 
 **一般的なトラブルシューティング:**
 - `npm ci` が失敗する場合: Node.js v20+ がインストールされているか確認
-- `npm run validate` が失敗する場合: agents/ または rules/ ディレクトリの .md ファイルの frontmatter 構文を確認
+- `npm run validate` が失敗する場合: agents/ または rules/ ディレクトリの .md ファイルの frontmatter 構文と、agent/rule の name 重複を確認
 - シムリンクが作成されない場合: `npm run setup -- --force` を試す（既存のディレクトリはバックアップされます）
 - `error_code` 単位の詳細対処: [docs/troubleshooting.md](./docs/troubleshooting.md)
 
@@ -179,7 +179,8 @@ mantra/
 
 補足:
 - 同名ファイルは「後から読まれたソース」が優先されます
-- 衝突ポリシーは `warning` を出しつつユーザー定義を優先します（filename/name）
+- 衝突ポリシーは filename 衝突のみで、`W_SOURCE_CONFLICT_FILENAME` warning を出してユーザー定義を優先します
+- agent/rule の name 重複は warning ではなく、`validate:agents|validate:rules` で `E_INPUT_INVALID` として失敗します
 - ユーザー定義がある場合、`setup` は `~/.mantra/generated/*` にマージして `~/.claude/agents|rules` へリンクします
 
 ロードマップ上の位置づけ:

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -42,7 +42,7 @@
 ```json
 {
   "type": "warning",
-  "command": "sync:codex:agents",
+  "command": "setup",
   "code": "W_SOURCE_CONFLICT_FILENAME",
   "winner": "user",
   "loser": "core",
@@ -53,9 +53,9 @@
 
 - `code`:
   - `W_SOURCE_CONFLICT_FILENAME`
-  - `W_SOURCE_CONFLICT_NAME`
 - `winner`: `user`
 - `loser`: `core` または `user:<path>`
+- 重複した agent/rule name は warning ではなく、`validate:agents|validate:rules` の `type: "error"` イベントで `E_INPUT_INVALID` を返し、終了コード `1` で失敗
 
 ## error_code 一覧
 

--- a/docs/ops-metrics.md
+++ b/docs/ops-metrics.md
@@ -18,8 +18,9 @@
   - 定義: 実行時に user source が1つ以上解決された割合
   - 式: `user source 利用実行数 / 実行数`
 - **衝突 warning 率**
-  - 定義: filename/name 衝突 warning の発生割合
+  - 定義: filename 衝突 warning（`W_SOURCE_CONFLICT_FILENAME`）の発生割合
   - 式: `warning 発生実行数 / 実行数`
+  - 補足: agent/rule の name 重複は warning ではなく、`E_INPUT_INVALID` の失敗として「コマンド失敗率」に計上
 - **原因特定時間（MTTI）**
   - 定義: 最初の失敗発生から `error_code` と対処手順が特定されるまでの時間
 - **初回完了時間（P50）**

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -6,18 +6,18 @@
 ## Warning（非致命）
 
 `type: "warning"` は失敗ではありません。  
-外部ソースと core の衝突がある場合、warning を出してユーザー定義を優先します。
+ソース間で filename 衝突がある場合、`W_SOURCE_CONFLICT_FILENAME` warning を出してユーザー定義を優先します。
 
-主な warning code:
+warning code:
 - `W_SOURCE_CONFLICT_FILENAME`
-- `W_SOURCE_CONFLICT_NAME`
 
 確認:
-- `npm run sync:codex:agents -- --json`
-- `npm run sync:codex:rules -- --json`
+- `npm run setup -- --json`
+- `npm run onboarding:json`
 
 見方:
 - `winner: "user"` と `loser` を確認し、どちらが採用されたかを判断する
+- 注意: agent/rule の name 重複は warning ではなく、`E_INPUT_INVALID` エラーです
 
 ## E_ENV_NODE_VERSION
 
@@ -57,6 +57,17 @@
   - 出力先が `~/.codex/skills/mantra*` 配下であることを確認
   - 手動で不正なシンボリックリンクを作成していないか確認
 
+## E_INPUT_INVALID
+
+- 症状: 入力値/設定不正（例: agent/rule の name 重複、sources.json の JSON/スキーマ不正）
+- 確認:
+  - `npm run validate:agents -- --json`
+  - `npm run validate:rules -- --json`
+- 補足: 重複 name の場合は `type: "error"` 行の `error_code` に `E_INPUT_INVALID` が出力されます
+- 対処:
+  - agent/rule の `name` を一意にする
+  - `~/.config/mantra/sources.json` の JSON とスキーマを修正する
+
 ## E_IO / E_INTERNAL
 
 - 症状: 想定外の I/O 失敗または内部エラー
@@ -78,13 +89,13 @@
 
 簡易確認:
 1. `npm run validate:json`
-2. `npm run sync:codex:agents -- --json`
-3. warningイベントで採用元を確認
+2. `npm run setup -- --json`
+3. warning イベント（`W_SOURCE_CONFLICT_FILENAME`）で採用元を確認
 
 ## 最短診断フロー
 
 1. `npm run onboarding:json`
-2. `npm run sync:codex:agents -- --json`
-3. `npm run sync:codex:rules -- --json`
+2. `npm run setup -- --json`
+3. `npm run validate:json`
 4. warning/error を確認して上記セクションの対処を実施
 5. `npm run smoke:onboarding` で再検証

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint": "eslint \"scripts/**/*.ts\" \"tests/**/*.ts\" --max-warnings=0",
     "test": "vitest",
     "test:run": "vitest run",
-    "test:unit": "vitest run tests/agents.test.ts tests/rules.test.ts tests/contracts/cli-json-contract.test.ts tests/contracts/package-scripts-contract.test.ts",
+    "test:unit": "vitest run tests/agents.test.ts tests/rules.test.ts tests/contracts/cli-json-contract.test.ts tests/contracts/package-scripts-contract.test.ts tests/contracts/content-precedence.test.ts tests/contracts/name-conflict-contract.test.ts",
     "smoke:onboarding": "vitest run tests/smoke/onboarding.test.ts",
     "validate:agents": "tsx scripts/validate-agents.ts",
     "validate:rules": "tsx scripts/validate-rules.ts",

--- a/scripts/lib/cli-telemetry.ts
+++ b/scripts/lib/cli-telemetry.ts
@@ -12,7 +12,7 @@ export type CliErrorCode =
   | 'E_IO'
   | 'E_INTERNAL'
 
-export type WarningCode = 'W_SOURCE_CONFLICT_FILENAME' | 'W_SOURCE_CONFLICT_NAME'
+export type WarningCode = 'W_SOURCE_CONFLICT_FILENAME'
 
 export interface WarningEvent {
   type: 'warning'

--- a/tests/contracts/name-conflict-contract.test.ts
+++ b/tests/contracts/name-conflict-contract.test.ts
@@ -1,0 +1,112 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createTempHome, removeTempHome, runScript, type CliRunResult } from '../helpers/cli-runner'
+
+function createTempDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix))
+}
+
+function writeAgent(filePath: string, name: string): void {
+  fs.writeFileSync(
+    filePath,
+    `---\nname: ${name}\ndescription: Name conflict contract\ntools: []\n---\nBody\n`,
+    'utf8',
+  )
+}
+
+function writeRule(filePath: string, heading: string): void {
+  fs.writeFileSync(filePath, `# ${heading}\n\nBody\n`, 'utf8')
+}
+
+function runValidateAgentsWithDuplicateNames(home: string, tempDirs: string[]): CliRunResult {
+  const userAgentsDir = createTempDir('mantra-dup-agent-')
+  tempDirs.push(userAgentsDir)
+
+  writeAgent(path.join(userAgentsDir, 'dup-a.md'), 'duplicate-agent-contract')
+  writeAgent(path.join(userAgentsDir, 'dup-b.md'), 'duplicate-agent-contract')
+
+  return runScript('validate-agents.ts', ['--json'], home, {
+    MANTRA_USER_AGENTS_DIRS: userAgentsDir,
+  })
+}
+
+describe('Name conflict contract', () => {
+  const homes: string[] = []
+  const tempDirs: string[] = []
+
+  afterEach(() => {
+    while (homes.length > 0) {
+      removeTempHome(homes.pop() as string)
+    }
+    while (tempDirs.length > 0) {
+      fs.rmSync(tempDirs.pop() as string, { recursive: true, force: true })
+    }
+  })
+
+  it('returns E_INPUT_INVALID for duplicate agent names', () => {
+    const home = createTempHome('mantra-dup-agent-contract-')
+    homes.push(home)
+
+    const result = runValidateAgentsWithDuplicateNames(home, tempDirs)
+    expect(result.raw.status, result.stderr).toBe(1)
+
+    const duplicateError = result.jsonLines.find(
+      line =>
+        line.type === 'error' &&
+        line.error_code === 'E_INPUT_INVALID' &&
+        String(line.message).includes('重複した agent name'),
+    )
+    expect(duplicateError).toBeDefined()
+
+    const summary = result.jsonLines.find(line => line.type === 'summary')
+    expect(summary?.success).toBe(false)
+    expect(summary?.error_code).toBe('E_SCHEMA_FRONTMATTER')
+  })
+
+  it('returns E_INPUT_INVALID for duplicate rule names', () => {
+    const home = createTempHome('mantra-dup-rule-contract-')
+    homes.push(home)
+
+    const userRulesDirA = createTempDir('mantra-dup-rule-a-')
+    const userRulesDirB = createTempDir('mantra-dup-rule-b-')
+    tempDirs.push(userRulesDirA, userRulesDirB)
+
+    writeRule(path.join(userRulesDirA, 'duplicate-rule-contract.md'), 'Duplicate Rule A')
+    writeRule(path.join(userRulesDirB, 'duplicate-rule-contract.md'), 'Duplicate Rule B')
+
+    const result = runScript('validate-rules.ts', ['--json'], home, {
+      MANTRA_USER_RULES_DIRS: `${userRulesDirA},${userRulesDirB}`,
+    })
+    expect(result.raw.status, result.stderr).toBe(1)
+
+    const duplicateError = result.jsonLines.find(
+      line =>
+        line.type === 'error' &&
+        line.error_code === 'E_INPUT_INVALID' &&
+        String(line.message).includes('重複した rule name'),
+    )
+    expect(duplicateError).toBeDefined()
+
+    const summary = result.jsonLines.find(line => line.type === 'summary')
+    expect(summary?.success).toBe(false)
+    expect(summary?.error_code).toBe('E_SCHEMA_RULE')
+  })
+
+  it('does not emit warning contract fields on validation failure paths', () => {
+    const home = createTempHome('mantra-no-warning-contract-')
+    homes.push(home)
+
+    const result = runValidateAgentsWithDuplicateNames(home, tempDirs)
+    expect(result.raw.status, result.stderr).toBe(1)
+
+    const warningLines = result.jsonLines.filter(line => line.type === 'warning')
+    expect(warningLines).toHaveLength(0)
+
+    const summary = result.jsonLines.find(line => line.type === 'summary')
+    expect(summary?.success).toBe(false)
+    expect(summary?.warning_count).toBeUndefined()
+    expect(summary?.warning_types).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

Aligns public contract docs to current runtime semantics for source conflicts and duplicate names.

- Warning contract is now explicitly **filename-conflict only** (`W_SOURCE_CONFLICT_FILENAME`)
- Duplicate `agent/rule name` is documented as a **validation failure path** (`E_INPUT_INVALID` on `type:"error"` events)
- Added contract test coverage for duplicate-name failure behavior
- Included precedence contract test in `test:unit` to keep behavior locked in CI

## Changes

- `scripts/lib/cli-telemetry.ts`
  - Removed stale warning code exposure: `W_SOURCE_CONFLICT_NAME`
- `tests/contracts/name-conflict-contract.test.ts` (new)
  - Duplicate agent name -> validation failure and `E_INPUT_INVALID` error event
  - Duplicate rule name -> validation failure and `E_INPUT_INVALID` error event
  - Validation failure path does not emit warning events
- `package.json`
  - Extended `test:unit` to include:
    - `tests/contracts/content-precedence.test.ts`
    - `tests/contracts/name-conflict-contract.test.ts`
- Docs updated to match runtime behavior:
  - `README.md`
  - `docs/cli-contract.md`
  - `docs/ops-metrics.md`
  - `docs/troubleshooting.md`

## Validation

Executed in strict order and all passed:

1. `npm ci`
2. `npm run validate`
3. `npm run typecheck`
4. `npm run lint`
5. `npm run test:unit`
6. `npm run smoke:onboarding`

## Design Decision

`name` conflict warning was intentionally **not** implemented. We keep runtime behavior as-is:

- `filename` collisions -> warning + user source precedence
- duplicate `name` -> validation error path

This avoids introducing a new warning semantic and keeps contract aligned with shipped behavior.

Closes #2