### PR TITLE
Introduce cross-repo harness MVH contracts

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+npm run verify

--- a/README.md
+++ b/README.md
@@ -218,9 +218,27 @@ mantra/
 | `npm run validate:drift` | `drift_guard.enabled: true` の family drift を検証 |
 | `npm run typecheck` | scripts/tests の TypeScript 型検査 |
 | `npm run lint` | scripts/tests の ESLint チェック（warning も fail） |
+| `npm run verify` | canonical verify（validate + typecheck + lint + unit/contract） |
 | `npm run test:unit` | ユニット + 契約テストの実行 |
 | `npm run test:coverage` | ユニット + 契約テストを coverage gate（80%）付きで実行 |
 | `npm run smoke:onboarding` | onboarding フローのスモークテスト |
+
+## Harness Engineering / MVH
+
+repo 横断の最小実行可能ハーネス（MVH: Minimum Viable Harness）の正本は次を参照します。
+
+- [docs/harness-engineering.md](./docs/harness-engineering.md)
+- [templates/repo-agents-pointer.md](./templates/repo-agents-pointer.md)
+- [templates/repo-pre-push.example.sh](./templates/repo-pre-push.example.sh)
+- [templates/repo-obsidian-ledger.md](./templates/repo-obsidian-ledger.md)
+
+このセットで定義する内容:
+
+- 1画面で読めるポインタ型 `AGENTS.md`
+- repo ごとに 1 本へ寄せる canonical verify command
+- unit / visual / acceptance の test ladder
+- PreToolUse / PostToolUse / Stop と repo hook の役割分担
+- `maw handover/takeover` と Obsidian ledger を使う継続契約
 
 ### 導線ガイド / Execution guidance
 

--- a/docs/harness-engineering.md
+++ b/docs/harness-engineering.md
@@ -1,0 +1,152 @@
+# Harness Engineering MVH
+
+このドキュメントは、この Mac 上の複数 repo に共通で入れる最小実行可能ハーネス
+（MVH: Minimum Viable Harness）の正本です。
+
+目標は「深い repo ごとの差異を残したまま、毎回迷わず同じ入口で始められる薄い共通層」を作ることです。
+
+## 1. Thin AGENTS Contract
+
+`AGENTS.md` は入口だけを持ち、仕様・背景・長い運用メモは別ドキュメントへ送ります。
+
+必須要素:
+
+- `Purpose`: この repo のハーネス上の優先事項
+- `Canonical verify`: まず実行すべき 1 本の検証コマンド
+- `Test ladder`: unit / visual / acceptance の位置づけ
+- `Session continuity`: `maw handover/takeover` と ledger の参照先
+- `Canonical docs`: 詳細の SSOT
+
+非推奨:
+
+- エージェント一覧の長文再掲
+- 詳細 runbook のコピペ
+- 実装仕様の長文化
+- 同じ趣旨の rule を複数ファイルへ重複記載
+
+推奨長さ:
+
+- 1 画面で読める量
+- まず最初の 60 秒で「どこを見て、何を打てばよいか」が分かる量
+
+## 2. Policy-as-Code Hooks
+
+ハーネス上の hook は「説明」ではなく「機械で実行される軽いガード」を置きます。
+
+### PreToolUse / Pre-execution
+
+責務:
+
+- 破壊的操作の遮断または確認
+- dirty tree での直接編集を避ける
+- `maw` / worktree の利用を促す
+- 高リスク作業を plan-first に戻す
+
+代表例:
+
+- `git reset --hard`, `rm -rf`, `fly deploy`, `sudo` を即時ブロック
+- 3+ step / migration / public contract change は plan-first を促す
+- 既存未コミット差分がある tree では隔離 workspace を要求する
+
+### PostToolUse / Post-edit
+
+責務:
+
+- 変更直後の軽量 verify
+- changed-file 単位の lint / typecheck
+- 補助 artifact の場所を示す
+
+代表例:
+
+- TypeScript 編集後に `tsc --noEmit` または repo verify の軽量版
+- visual diff の出力先を案内
+- 受け入れテスト runbook への導線を出す
+
+### Stop / Session end
+
+責務:
+
+- verify 漏れ検知
+- handover 漏れ検知
+- 継続に必要な evidence の確認
+
+代表例:
+
+- 変更があるのに verify 実行記録が無ければ警告
+- `maw` workspace なら `maw handover` 未実施を警告
+- ledger に `next step` と `evidence refs` が無ければ補完を促す
+
+### Repo Hook Contract
+
+editor/tool hook が無い環境でも最低限効くように、repo 側には `pre-push` を置きます。
+
+期待値:
+
+- 1 repo 1 command の canonical verify を呼ぶ
+- 追加で重い visual / acceptance は手動トリガに残す
+- 実行時間は「毎 push で耐えられる」範囲に抑える
+
+ひな形は [templates/repo-pre-push.example.sh](../templates/repo-pre-push.example.sh) を使います。
+
+## 3. Plan / Execute Split
+
+次の条件では plan-first を既定にします。
+
+- 3 つ以上の実装ステップ
+- 2 ファイル以上で public behavior が変わる
+- migration / auth / billing / data loss risk
+- rollback が難しい
+
+軽微な docs-only や 1 ファイルの明確な修正では single-agent execute-first で構いません。
+
+重要なのは「plan-first を AGENTS に長文で埋める」ことではなく、「高リスク時だけ確実に戻れること」です。
+
+## 4. Canonical Verify Contract
+
+各 repo は人間にも agent にも分かりやすい 1 本の verify command を持ちます。
+
+例:
+
+- `eval "$(mise env -s zsh)" && npm run verify`
+- `corepack yarn validate`
+- `npm run check`
+
+補助的な test は ladder で扱います。
+
+### Test ladder
+
+- `default`: unit / lint / typecheck / contract
+- `visual`: UI, rendering, CLI layout 変更時のみ
+- `acceptance`: 重要フロー、外部連携、リリース前ゲートのみ
+
+原則:
+
+- visual を常時必須にしない
+- acceptance を全 push に載せない
+- ただし runbook と artifact の置き場は常に明示する
+
+## 5. Session Continuity Contract
+
+継続の source of truth は `maw handover/takeover` です。
+
+Obsidian は検索・俯瞰・一覧のための index として使い、handover の代替にはしません。
+
+最低限そろえるメタデータ:
+
+- `repo`
+- `branch_or_workspace`
+- `goal`
+- `blockers`
+- `next_step`
+- `evidence_refs`
+- `updated_at`
+
+Obsidian 用の雛形は [templates/repo-obsidian-ledger.md](../templates/repo-obsidian-ledger.md) を使います。
+
+## 6. Recommended Rollout
+
+1. `AGENTS.md` をポインタ型へ薄くする
+2. canonical verify command を明記する
+3. repo `pre-push` を canonical verify に寄せる
+4. visual / acceptance の手動 runbook を docs へ寄せる
+5. `maw handover/takeover` と ledger をセットで運用する

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test": "vitest",
     "test:run": "vitest run",
     "test:unit": "vitest run tests/agents.test.ts tests/rules.test.ts tests/contracts tests/setup-fs.test.ts tests/setup-merge.test.ts tests/setup-orchestrator.test.ts",
+    "verify": "npm run validate && npm run typecheck && npm run lint && npm run test:unit",
     "test:coverage": "vitest run --coverage tests/agents.test.ts tests/rules.test.ts tests/contracts tests/setup-fs.test.ts tests/setup-merge.test.ts tests/setup-orchestrator.test.ts",
     "smoke:onboarding": "vitest run tests/smoke/onboarding.test.ts",
     "validate:agents": "tsx scripts/validate-agents.ts",

--- a/rules/agents.md
+++ b/rules/agents.md
@@ -56,6 +56,24 @@ Use this sequence:
 Suggested escalation:
 - `single-agent` → `planner` (if P1) → `replan` (if P2) → `mob-navigator`/`mob-critic`/`mob-scribe` (if P3) → `code-reviewer` (if P4)
 
+## Plan / Execute Split
+
+Keep planning and execution separate when:
+
+- work spans 3+ implementation steps
+- change touches multiple files and alters behavior
+- auth / migration / billing / data-loss risk exists
+- rollback is hard
+
+In those cases:
+
+- use a planner first
+- keep `AGENTS.md` thin and point to SSOT docs instead of embedding long playbooks
+- expose one canonical verify command and one test ladder per repo
+
+See [docs/harness-engineering.md](../docs/harness-engineering.md) and
+[templates/repo-agents-pointer.md](../templates/repo-agents-pointer.md).
+
 ## Parallel Task Execution
 
 ALWAYS use parallel Task execution for independent operations:

--- a/rules/hooks.md
+++ b/rules/hooks.md
@@ -1,46 +1,50 @@
 # Hooks System
 
+hook は「便利機能」ではなく、薄いハーネスを常時効かせるための policy-as-code 層として扱います。
+
+詳細契約は [docs/harness-engineering.md](../docs/harness-engineering.md) を参照してください。
+
 ## Hook Types
 
-- **PreToolUse**: Before tool execution (validation, parameter modification)
-- **PostToolUse**: After tool execution (auto-format, checks)
-- **Stop**: When session ends (final verification)
+- `PreToolUse`: 実行前の危険操作ガードと隔離 workspace の強制
+- `PostToolUse`: 編集直後の軽量 verify と artifact 導線
+- `Stop`: verify / handover 漏れの検知
 
-## Current Hooks (in ~/.claude/settings.json)
+## Required Behavior
 
 ### PreToolUse
-- **dangerous action guard**: Blocks irreversible/destructive/security/monetary Bash commands and requires chat confirmation (git reset --hard, rm -rf, fly deploy, sudo, etc.)
-- **tmux reminder**: Suggests tmux for long-running commands (npm, pnpm, yarn, cargo, etc.)
-- **git push review**: Opens Zed for review before push
+
+- `git reset --hard`, `rm -rf`, `sudo`, deploy 系などの高リスク操作をブロックまたは確認する
+- dirty tree での直接編集を避け、`maw` / worktree を促す
+- 3+ step、高リスク、public contract change は plan-first に戻す
 
 ### PostToolUse
-- **PR creation**: Logs PR URL and GitHub Actions status
-- **Prettier**: Auto-formats JS/TS files after edit
-- **TypeScript check**: Runs tsc after editing .ts/.tsx files
-- **console.log warning**: Warns about console.log in edited files
+
+- repo の canonical verify command か、その軽量部分集合を実行する
+- changed-file 単位で lint / typecheck を優先し、毎回のコストを抑える
+- visual / acceptance が必要な変更では runbook や artifact 置き場を示す
 
 ### Stop
-- **console.log audit**: Checks all modified files for console.log before session ends
+
+- 変更があるのに verify 記録が無い場合は警告する
+- `maw` workspace 作業なら `maw handover` 未実施を警告する
+- `next step` と `evidence refs` が無い継続状態を残さない
+
+## Repo Hook Pairing
+
+editor/tool hook が無い環境でも最低限の品質ゲートを通すため、repo 側には `pre-push` を置きます。
+
+- 1 repo 1 command の canonical verify を呼ぶ
+- visual / acceptance は手動 runbook に残す
+- ひな形は [templates/repo-pre-push.example.sh](../templates/repo-pre-push.example.sh)
 
 ## Auto-Accept Permissions
 
 Use with caution:
-- Enable for trusted, well-defined plans
+- Enable only for trusted, well-defined plans
 - Disable for exploratory work
-- Never use dangerously-skip-permissions flag
-- Configure `allowedTools` in `~/.claude.json` instead
+- Never use `dangerously-skip-permissions`
 
-## TodoWrite Best Practices
+## Todo / Plan Tracking
 
-Use TodoWrite tool to:
-- Track progress on multi-step tasks
-- Verify understanding of instructions
-- Enable real-time steering
-- Show granular implementation steps
-
-Todo list reveals:
-- Out of order steps
-- Missing items
-- Extra unnecessary items
-- Wrong granularity
-- Misinterpreted requirements
+Use Todo-style tracking to keep multi-step work visible, especially when a task crosses plan / execute boundaries.

--- a/templates/repo-agents-pointer.md
+++ b/templates/repo-agents-pointer.md
@@ -1,0 +1,27 @@
+# Agent Operations (<repo>)
+
+## Purpose
+- このファイルは運用入口のみを定義する。
+- 仕様や背景は SSOT に寄せ、このファイルへ再掲しない。
+
+## Canonical Verify
+- `<canonical verify command>`
+
+## Test Ladder
+- `default`: `<unit/lint/typecheck/contract>`
+- `visual`: `<when to run visual regression>`
+- `acceptance`: `<when to run acceptance or E2E>`
+
+## Session Continuity
+- source of truth は `maw handover/takeover`
+- Obsidian ledger には `repo / branch_or_workspace / goal / blockers / next_step / evidence_refs` を残す
+
+## Canonical Docs
+- `README.md`
+- `<repo harness doc>`
+- `<repo runbook>`
+
+## Non-Goals
+- 長い運用メモの再掲
+- 実装仕様の説明
+- 詳細 runbook の複製

--- a/templates/repo-obsidian-ledger.md
+++ b/templates/repo-obsidian-ledger.md
@@ -1,0 +1,28 @@
+---
+repo: <repo>
+branch_or_workspace: <branch-or-workspace>
+goal: <one-line-goal>
+blockers:
+  - none
+next_step: <next-concrete-step>
+evidence_refs:
+  - <path-or-url>
+updated_at: <YYYY-MM-DD HH:mm JST>
+source_of_truth: maw_handover
+---
+
+# <repo> - <goal>
+
+## Context
+- repo: `<repo>`
+- branch/workspace: `<branch-or-workspace>`
+- source of truth: `maw handover/takeover`
+
+## Blockers
+- none
+
+## Next Step
+- `<next-concrete-step>`
+
+## Evidence
+- `<path-or-url>`

--- a/templates/repo-pre-push.example.sh
+++ b/templates/repo-pre-push.example.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+cd "${ROOT_DIR}"
+
+# Keep the always-on hook thin: call exactly one canonical verify command.
+<canonical verify command>
+
+# Optional, human-facing reminder for heavier gates.
+echo "[harness] visual/acceptance gates remain opt-in and runbook-driven."


### PR DESCRIPTION
## Summary
- add a shared Harness Engineering MVH doc and repo templates
- introduce a canonical `npm run verify` path for mantra itself
- document policy-as-code hooks and the thin AGENTS contract

## What Changed
- add `docs/harness-engineering.md`
- add templates for repo AGENTS pointers, pre-push hooks, and Obsidian ledgers
- update `rules/hooks.md` and `rules/agents.md` to encode plan/execute and hook contracts
- add `npm run verify` and a `pre-push` hook for mantra

## Verification
- `npm run verify`

## Notes
- this PR is the SSOT layer that the repo-specific harness updates build on top of
