### PR TITLE
chore: pin GitHub Actions to commit SHA

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           cache: npm


### PR DESCRIPTION
## Summary
- `validate.yml` の checkout, setup-node を SHA ピン留めに変更
- 他の mantra workflow (risk-classifier, ai-review) は既に SHA ピン留め済み
- セキュリティ監査で検出された supply-chain attack リスクへの対応

## Test plan
- [ ] PR / push 時の validate workflow が正常に実行されることを確認