### PR TITLE
feat: introduce Named Failure Modes (FM-xxx) to rules system

### DIFF
--- a/rules/agents.md
+++ b/rules/agents.md
@@ -151,3 +151,9 @@ Tagged outputs for structured collaboration:
 **IMPORTANT**: Always include mob-critic for challenging assumptions. Use mob-scribe to normalize outputs before acting.
 
 See `rules/mob-programming.md` for complete protocol.
+
+## Named Failure Modes
+
+- **FM-AGENT-TARGET**: エージェント起動前に決定対象を定義する。目的なき起動はノイズを生む。
+- **FM-AGENT-CRITIC**: セキュリティ・認証・課金・マイグレーション変更では必ずチャレンジ役を含める。
+- **FM-READ**: エージェント出力の要約は検証済み事実ではない。実際のツール実行で確認する。

--- a/rules/coding-style.md
+++ b/rules/coding-style.md
@@ -68,3 +68,9 @@ Before marking work complete:
 - [ ] No console.log statements
 - [ ] No hardcoded values
 - [ ] No mutation (immutable patterns used)
+
+## Named Failure Modes
+
+- **FM-CODE-SCOPE**: 現在のタスクスコープ外のコードをリファクタ・整理しない。
+- **FM-CODE-CREEP**: 要求された機能のみ実装する。「ついでに」の改善は記録するだけで実行しない。
+- **FM-PLAUSIBLE**: もっともらしい実装はテスト済みの実装ではない。完了前に検証する。

--- a/rules/failure-modes.md
+++ b/rules/failure-modes.md
@@ -1,0 +1,88 @@
+# Named Failure Modes
+
+LLM エージェントが典型的にやらかす「ショートカット行動」の明示的禁止リスト。
+各パターンは FM-xxx ID を持ち、ドメインルールファイルから参照される。
+
+## Cross-Cutting Patterns
+
+### FM-READ: 「読んだ」≠「検証した」
+
+Do not treat reading a file, log, or document as verification.
+Reading confirms existence, not correctness. If a verification step exists (run tests, check output, call endpoint), execute it.
+
+### FM-PLAUSIBLE: 「もっともらしい」≠「テスト済み」
+
+Do not treat a likely-correct fix as a confirmed fix.
+If the fix can be tested in under 60 seconds, test it before declaring it done.
+
+### FM-SKIP-CHECK: 検証ステップを省略しない
+
+Do not skip a verification step that is available and takes seconds.
+"It should work" is not evidence.
+
+### FM-SUMMARY: 検索要約 ≠ 実装確認
+
+Do not treat search result summaries or code comments as proof of implementation.
+Trace through the actual execution path.
+
+### FM-RETRY: 拒否されたツール呼び出しを同一引数で再試行しない
+
+If a tool call is denied, do not re-issue the same call unchanged.
+Understand why it was denied, adjust the approach, or ask the user.
+
+### FM-VAGUE: 漠然とした質問をしない
+
+Do not ask broad clarifying questions when a specific missing piece can be identified.
+"Is the return type string or number?" not "Can you tell me more about the requirements?"
+
+## Domain-Specific Patterns
+
+### FM-TEST-PASS: ユニットテスト通過 ≠ フロー全体の証明
+
+A passing unit test does not prove the feature works end-to-end.
+When integration or E2E verification is available, use it.
+
+### FM-TEST-FIX: テストではなく実装を直す
+
+When a test fails, the default assumption is the implementation is wrong.
+Do not modify test expectations to match broken behavior unless the test itself is incorrect.
+
+### FM-SEC-INTERNAL: 内部入力も安全ではない
+
+Do not assume input from internal services or trusted sources is safe.
+Validate at every system boundary.
+
+### FM-SEC-SILENCE: 「エラーなし」≠「安全」
+
+The absence of error messages does not mean the code is secure.
+Actively verify security properties (auth, authz, injection, secrets exposure).
+
+### FM-GIT-AMEND: フック失敗後に amend しない
+
+When a pre-commit hook fails, the commit did not happen.
+Create a new commit after fixing — do not use `--amend`, which would modify the previous commit.
+
+### FM-GIT-NOVERIFY: フックやパーミッションガードをスキップしない
+
+Do not use `--no-verify`, `--no-gpg-sign`, or `dangerously-skip-permissions` to bypass failing hooks or permission guards.
+Fix the underlying issue instead.
+
+### FM-CODE-SCOPE: 無関係なコードを整理しない
+
+Do not refactor, rename, or reorganize code outside the scope of the current task.
+Use `refactor-cleaner` as a separate step after the feature is committed.
+
+### FM-CODE-CREEP: 要求以上の機能を追加しない
+
+Implement what was requested. Do not add "while I'm here" improvements.
+If you notice something worth improving, note it — do not act on it.
+
+### FM-AGENT-TARGET: 決定対象なしにエージェントを起動しない
+
+Before spawning agents, define what needs to be decided.
+Agents without a clear objective produce noise, not insight.
+
+### FM-AGENT-CRITIC: リスクの高い変更でチャレンジ役を省略しない
+
+For security, auth, billing, migration, or data-integrity changes, always include `mob-critic` or equivalent.
+Shallow consensus on high-risk changes is itself a failure mode.

--- a/rules/git-workflow.md
+++ b/rules/git-workflow.md
@@ -44,3 +44,9 @@ When creating PRs:
 4. **Commit & Push**
    - Detailed commit messages
    - Follow conventional commits format
+
+## Named Failure Modes
+
+- **FM-GIT-AMEND**: フック失敗後は新しいコミットを作成する。`--amend` で前のコミットを変更しない。
+- **FM-GIT-NOVERIFY**: `--no-verify` でフックをスキップしない。根本原因を修正する。
+- **FM-SKIP-CHECK**: PR を ready にする前に canonical verify コマンドを実行する。

--- a/rules/hooks.md
+++ b/rules/hooks.md
@@ -48,3 +48,8 @@ Use with caution:
 ## Todo / Plan Tracking
 
 Use Todo-style tracking to keep multi-step work visible, especially when a task crosses plan / execute boundaries.
+
+## Named Failure Modes
+
+- **FM-GIT-NOVERIFY**: `dangerously-skip-permissions` や `--no-verify` でフックをバイパスしない。
+- **FM-SKIP-CHECK**: フックが存在するなら理由がある。失敗を修正し、迂回しない。

--- a/rules/mob-programming.md
+++ b/rules/mob-programming.md
@@ -195,6 +195,15 @@ Use `mob-scribe` and produce this exact structure:
 
 ---
 
+## Named Failure Modes
+
+- **FM-AGENT-TARGET**: エージェント起動前に決定対象を定義する。目的なき起動はノイズを生む。
+- **FM-AGENT-CRITIC**: セキュリティ・認証・課金・マイグレーション変更では必ず `mob-critic` を含める。
+- **FM-READ**: エージェント観察結果は検証済み事実ではない。ツール実行で確認する。
+- **FM-SUMMARY**: モブ議事録は検証済み計画ではない。`mob-scribe` で正規化してから行動する。
+
+---
+
 ## Anti-patterns to Avoid
 
 ### 1. Calling Many Agents Without a Decision Target

--- a/rules/security.md
+++ b/rules/security.md
@@ -34,3 +34,9 @@ If security issue found:
 3. Fix CRITICAL issues before continuing
 4. Rotate any exposed secrets
 5. Review entire codebase for similar issues
+
+## Named Failure Modes
+
+- **FM-SEC-INTERNAL**: 内部サービスからの入力も安全とは限らない。全境界で検証する。
+- **FM-SEC-SILENCE**: 「エラーなし」は「安全」を意味しない。セキュリティ特性を能動的に検証する。
+- **FM-READ**: セキュリティ設定を読んだだけでは検証にならない。実際の動作をテストする。

--- a/rules/teams.md
+++ b/rules/teams.md
@@ -106,6 +106,14 @@ Task received
 
 ---
 
+## Named Failure Modes
+
+- **FM-AGENT-TARGET**: チーム作成前にタスク目標を定義する。明確なタスクなきチームはリソースを浪費する。
+- **FM-SKIP-CHECK**: チームメンバーの出力をマージ前に検証する。並列作業は統合リスクを高める。
+- **FM-AGENT-CRITIC**: セキュリティ・認証・課金・マイグレーション変更のチームでは必ずチャレンジ役を含める。
+
+---
+
 ## Anti-patterns
 
 ### Overuse of Team

--- a/rules/testing.md
+++ b/rules/testing.md
@@ -37,3 +37,10 @@
 
 - **tdd-guide** - Use PROACTIVELY for new features, enforces write-tests-first
 - **e2e-runner** - Playwright E2E testing specialist
+
+## Named Failure Modes
+
+- **FM-TEST-PASS**: ユニットテスト通過はフロー全体の証明ではない。integration/E2E が使えるなら実行する。
+- **FM-TEST-FIX**: テスト期待値ではなく実装を直す。壊れた動作に合わせてテストを変えない。
+- **FM-PLAUSIBLE**: もっともらしい修正は確認済みの修正ではない。テストを実行してから完了とする。
+- **FM-SKIP-CHECK**: 検証ステップが存在するなら実行する。「動くはず」は根拠にならない。

--- a/scripts/lib/rule-parser.ts
+++ b/scripts/lib/rule-parser.ts
@@ -38,6 +38,7 @@ const RULE_TRIGGER_MAP: Record<string, string> = {
   security: 'Apply security rules (secrets, input validation, OWASP) when writing or reviewing security-sensitive code',
   'pr-automation': 'Apply PR automation rules (risk classification, auto-merge, AI review) when configuring CI/CD',
   'mob-programming': 'Apply mob programming rules (flash-mob, plan-mob, review-mob) when running multi-agent collaboration',
+  'failure-modes': 'Apply named failure mode prohibitions (verification shortcuts, scope creep, test manipulation) to prevent known LLM failure patterns',
 }
 
 export function buildRuleDescription(name: string, content: string): string {


### PR DESCRIPTION
## Summary

- `rules/failure-modes.md` をマスターレジストリとして新規作成（16パターン、FM-xxx ID付き）
- 既存8ルールファイルに `## Named Failure Modes` セクションを埋め込み（障害隔離のための意図的重複）
- `scripts/lib/rule-parser.ts` の RULE_TRIGGER_MAP にエントリ追加

### 設計判断

[kropdx/unofficial-claude-code-prompt-playbook](https://github.com/kropdx/unofficial-claude-code-prompt-playbook) の分析に基づき **Option C（ハイブリッド）** を採用。マスターレジストリで一覧性を確保しつつ、ドメインファイルへの埋め込みで「制約は失敗ポイントで繰り返す」原則を実現。

### パターン一覧

| ID | Category | Description |
|---|---|---|
| FM-READ | Cross-cutting | 「読んだ」≠「検証した」 |
| FM-PLAUSIBLE | Cross-cutting | 「もっともらしい」≠「テスト済み」 |
| FM-SKIP-CHECK | Cross-cutting | 検証ステップを省略しない |
| FM-SUMMARY | Cross-cutting | 検索要約 ≠ 実装確認 |
| FM-RETRY | Cross-cutting | 拒否されたツール呼び出しを再試行しない |
| FM-VAGUE | Cross-cutting | 漠然とした質問をしない |
| FM-TEST-PASS | Testing | ユニットテスト ≠ フロー全体の証明 |
| FM-TEST-FIX | Testing | テストではなく実装を直す |
| FM-SEC-INTERNAL | Security | 内部入力も安全ではない |
| FM-SEC-SILENCE | Security | 「エラーなし」≠「安全」 |
| FM-GIT-AMEND | Git | フック失敗後に amend しない |
| FM-GIT-NOVERIFY | Git | フック/パーミッションガードをスキップしない |
| FM-CODE-SCOPE | Coding | 無関係なコードを整理しない |
| FM-CODE-CREEP | Coding | 要求以上の機能を追加しない |
| FM-AGENT-TARGET | Agents | 決定対象なしにエージェントを起動しない |
| FM-AGENT-CRITIC | Agents | リスクの高い変更でチャレンジ役を省略しない |

Closes #47

## Test plan

- [x] `npm run verify` 通過（validate + typecheck + lint + test:unit）
- [x] `tests/rules.test.ts` が新ファイルを自動検出し 16 tests 通過
- [ ] CI checks green