### PR TITLE
fix: move AI review trigger to git pre-push hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "input=$(cat); cmd=$(echo \"$input\" | jq -r '.tool_input.command // \"\"'); output=$(echo \"$input\" | jq -r 'if (.tool_response | type) == \"string\" then .tool_response else (.tool_response | tostring) end'); if echo \"$cmd\" | grep -q 'gh pr create'; then url=$(echo \"$output\" | grep -o 'https://github.com[^ ]*' | head -1); [ -n \"$url\" ] && echo \"{\\\"userMessage\\\": \\\"PR作成完了: $url\\\"}\"; fi"
+            "command": "input=$(cat | tr -d '\\000-\\010\\013-\\037'); cmd=$(echo \"$input\" | jq -r '.tool_input.command // \"\"'); output=$(echo \"$input\" | jq -r 'if (.tool_response | type) == \"string\" then .tool_response else (.tool_response | tostring) end'); if echo \"$cmd\" | grep -q 'gh pr create'; then url=$(echo \"$output\" | grep -o 'https://github.com[^ ]*' | head -1); [ -n \"$url\" ] && echo \"{\\\"userMessage\\\": \\\"PR作成完了: $url\\\"}\"; fi"
+          },
+          {
+            "type": "command",
+            "command": "input=$(cat | tr -d '\\000-\\010\\013-\\037'); cmd=$(echo \"$input\" | jq -r '.tool_input.command // \"\"'); output=$(echo \"$input\" | jq -r 'if (.tool_response | type) == \"string\" then .tool_response else (.tool_response | tostring) end'); if echo \"$cmd\" | grep -q 'gh pr create'; then cwd=$(echo \"$input\" | jq -r '.cwd // \".\"'); pr_num=$(echo \"$output\" | grep -oE '/pull/[0-9]+' | grep -oE '[0-9]+' | head -1); if [ -n \"$pr_num\" ] && [ -f \"$cwd/scripts/pr-review.sh\" ]; then if bash \"$cwd/scripts/pr-review.sh\" \"$pr_num\" > \"/tmp/pr-review-$pr_num.log\" 2>&1; then echo \"{\\\"userMessage\\\": \\\"AI review completed for #$pr_num\\\"}\"; else echo \"{\\\"userMessage\\\": \\\"AI review failed for #$pr_num (see /tmp/pr-review-$pr_num.log)\\\"}\"; fi; fi; fi",
+            "async": true
           }
         ]
       },

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,26 +11,6 @@
         ]
       },
       {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "input=$(cat); cmd=$(echo \"$input\" | jq -r '.tool_input.command // \"\"'); output=$(echo \"$input\" | jq -r 'if (.tool_response | type) == \"string\" then .tool_response else (.tool_response | tostring) end'); if echo \"$cmd\" | grep -q 'gh pr create'; then cwd=$(echo \"$input\" | jq -r '.cwd // \".\"'); pr_num=$(echo \"$output\" | grep -oE '/pull/[0-9]+' | grep -oE '[0-9]+' | head -1); if [ -n \"$pr_num\" ] && [ -f \"$cwd/scripts/pr-review.sh\" ]; then if bash \"$cwd/scripts/pr-review.sh\" \"$pr_num\" > \"/tmp/pr-review-$pr_num.log\" 2>&1; then echo \"{\\\"userMessage\\\": \\\"AI review completed for #$pr_num\\\"}\"; else echo \"{\\\"userMessage\\\": \\\"AI review failed for #$pr_num (see /tmp/pr-review-$pr_num.log)\\\"}\"; fi; fi; fi",
-            "async": true
-          }
-        ]
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "input=$(cat); cmd=$(echo \"$input\" | jq -r '.tool_input.command // \"\"'); output=$(echo \"$input\" | jq -r 'if (.tool_response | type) == \"string\" then .tool_response else (.tool_response | tostring) end'); if echo \"$cmd\" | grep -qE '^git push' && ! echo \"$output\" | grep -qiE '(rejected|error|fatal)'; then cwd=$(echo \"$input\" | jq -r '.cwd // \".\"'); pr_num=$(cd \"$cwd\" && gh pr view --json number -q .number 2>/dev/null); if [ -n \"$pr_num\" ] && [ -f \"$cwd/scripts/pr-review.sh\" ]; then if bash \"$cwd/scripts/pr-review.sh\" \"$pr_num\" > \"/tmp/pr-review-$pr_num.log\" 2>&1; then echo \"{\\\"userMessage\\\": \\\"AI review completed for #$pr_num\\\"}\"; else echo \"{\\\"userMessage\\\": \\\"AI review failed for #$pr_num (see /tmp/pr-review-$pr_num.log)\\\"}\"; fi; fi; fi",
-            "async": true
-          }
-        ]
-      },
-      {
         "matcher": "Edit|Write",
         "hooks": [
           {

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,11 +1,29 @@
+# Read pre-push stdin first (before verify consumes it).
+# git passes "<local-ref> <local-sha> <remote-ref> <remote-sha>" per line
+# for every ref being pushed. We save this to parse the SHA for the
+# current branch's upstream later.
+push_refs=$(cat)
+
 npm run verify
 
 # Run AI review in background (non-blocking).
-# Pass EXPECTED_SHA so pr-review.sh waits until remote catches up
-# to the commit being pushed before fetching diff and posting status.
+# Parse the SHA being pushed to the current branch's upstream from
+# stdin (not `git rev-parse HEAD`) so we handle `git push HEAD~1:branch`,
+# pushes of other branches, and multi-ref pushes correctly.
 if pr_num=$(gh pr view --json number -q .number 2>/dev/null); then
   if [ -n "$pr_num" ] && [ -f "scripts/pr-review.sh" ]; then
-    local_sha=$(git rev-parse HEAD)
-    EXPECTED_SHA="$local_sha" bash scripts/pr-review.sh "$pr_num" > "/tmp/pr-review-$pr_num.log" 2>&1 &
+    current_branch=$(git rev-parse --abbrev-ref HEAD)
+    upstream_ref="refs/heads/${current_branch}"
+    expected_sha=""
+    while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
+      [ -z "$local_ref" ] && continue
+      if [ "$remote_ref" = "$upstream_ref" ] && [ "$local_sha" != "0000000000000000000000000000000000000000" ]; then
+        expected_sha="$local_sha"
+        break
+      fi
+    done <<< "$push_refs"
+    if [ -n "$expected_sha" ]; then
+      EXPECTED_SHA="$expected_sha" bash scripts/pr-review.sh "$pr_num" > "/tmp/pr-review-$pr_num.log" 2>&1 &
+    fi
   fi
 fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,8 +1,11 @@
 npm run verify
 
-# Run AI review in background (non-blocking)
+# Run AI review in background (non-blocking).
+# Pass EXPECTED_SHA so pr-review.sh waits until remote catches up
+# to the commit being pushed before fetching diff and posting status.
 if pr_num=$(gh pr view --json number -q .number 2>/dev/null); then
   if [ -n "$pr_num" ] && [ -f "scripts/pr-review.sh" ]; then
-    bash scripts/pr-review.sh "$pr_num" > "/tmp/pr-review-$pr_num.log" 2>&1 &
+    local_sha=$(git rev-parse HEAD)
+    EXPECTED_SHA="$local_sha" bash scripts/pr-review.sh "$pr_num" > "/tmp/pr-review-$pr_num.log" 2>&1 &
   fi
 fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,8 @@
 npm run verify
+
+# Run AI review in background (non-blocking)
+if pr_num=$(gh pr view --json number -q .number 2>/dev/null); then
+  if [ -n "$pr_num" ] && [ -f "scripts/pr-review.sh" ]; then
+    bash scripts/pr-review.sh "$pr_num" > "/tmp/pr-review-$pr_num.log" 2>&1 &
+  fi
+fi

--- a/scripts/pr-review.sh
+++ b/scripts/pr-review.sh
@@ -28,6 +28,38 @@ trap 'rm -rf "$TMPDIR_REVIEW"' EXIT
 
 echo "[pr-review] Reviewing PR #${PR_NUMBER} in ${REPO}..."
 
+# --- 0. Wait for remote to catch up to EXPECTED_SHA (if provided) ---
+# When invoked from pre-push hook, the remote PR HEAD may not yet reflect
+# the commit being pushed. Poll until remote matches, with a timeout.
+EXPECTED_SHA="${EXPECTED_SHA:-}"
+if [ -n "$EXPECTED_SHA" ]; then
+  POLL_TIMEOUT="${POLL_TIMEOUT:-60}"
+  POLL_INTERVAL=2
+  echo "[pr-review] Waiting for remote PR HEAD to reach ${EXPECTED_SHA} (timeout: ${POLL_TIMEOUT}s)..."
+  ELAPSED=0
+  MATCHED=0
+  while [ "$ELAPSED" -lt "$POLL_TIMEOUT" ]; do
+    REMOTE_SHA=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid -q .headRefOid 2>/dev/null || echo "")
+    if [ "$REMOTE_SHA" = "$EXPECTED_SHA" ]; then
+      MATCHED=1
+      break
+    fi
+    sleep "$POLL_INTERVAL"
+    ELAPSED=$((ELAPSED + POLL_INTERVAL))
+  done
+  if [ "$MATCHED" -ne 1 ]; then
+    echo "[pr-review] Timeout: remote did not reach ${EXPECTED_SHA} within ${POLL_TIMEOUT}s" >&2
+    # Post failure on expected SHA to escape pending state
+    gh api "repos/${REPO}/statuses/${EXPECTED_SHA}" \
+      -X POST \
+      -f state="failure" \
+      -f context="ai-review/critical-findings" \
+      -f description="Remote did not catch up within ${POLL_TIMEOUT}s" 2>/dev/null || true
+    exit 1
+  fi
+  echo "[pr-review] Remote caught up to ${EXPECTED_SHA}"
+fi
+
 # --- 1. Pin HEAD SHA first to prevent race conditions ---
 gh pr view "$PR_NUMBER" --repo "$REPO" --json title,body,headRefOid > "${TMPDIR_REVIEW}/meta.json"
 PR_TITLE=$(jq -r '.title // "untitled"' "${TMPDIR_REVIEW}/meta.json")

--- a/scripts/pr-review.sh
+++ b/scripts/pr-review.sh
@@ -33,7 +33,9 @@ echo "[pr-review] Reviewing PR #${PR_NUMBER} in ${REPO}..."
 # the commit being pushed. Poll until remote matches, with a timeout.
 EXPECTED_SHA="${EXPECTED_SHA:-}"
 if [ -n "$EXPECTED_SHA" ]; then
-  POLL_TIMEOUT="${POLL_TIMEOUT:-60}"
+  # Default 300s (5 min) — pre-push fires before transfer completes,
+  # so this budget must cover the push upload itself on slow links.
+  POLL_TIMEOUT="${POLL_TIMEOUT:-300}"
   POLL_INTERVAL=2
   echo "[pr-review] Waiting for remote PR HEAD to reach ${EXPECTED_SHA} (timeout: ${POLL_TIMEOUT}s)..."
   ELAPSED=0


### PR DESCRIPTION
## Summary

Claude Code の PostToolUse Bash hook は以下の理由で信頼性が低く、ai-review/critical-findings が pending のまま止まる問題が発生していた:

- `git push` の出力（husky pre-push hook 出力を含む）に制御文字が混入 → `jq` パースエラーで `cmd` が空文字列になり、grep マッチせず `pr-review.sh` が呼ばれない
- 同じ `matcher: "Bash"` の hook グループが複数あると deduplication で一部しか実行されない
- 特に `async: true` の hook が一貫して発火しない

AI review のトリガーを `.husky/pre-push` に移動し、Claude Code セッションに依存せず確実に発火させる。

## Changes

- `.husky/pre-push`: `npm run verify` の後ろに `scripts/pr-review.sh` をバックグラウンド実行（`&` で非ブロッキング）
- `.claude/settings.json`: 冗長になった async Bash hook 2つを削除。PR URL 通知の同期 hook のみ残す

## Test plan

- [x] `npm run verify` 通過
- [x] git push で `.husky/pre-push` が発火し `/tmp/pr-review-<num>.log` が作成されることを確認（検証済み: 前PRで動作確認）
- [ ] マージ後、新しいPRで ai-review/critical-findings が自動で success/failure に遷移することを確認