### PR TITLE
docs: fix dead reference in ail example (#52)

### DIFF
--- a/examples/ja/ail-repo-improvement-loop.md
+++ b/examples/ja/ail-repo-improvement-loop.md
@@ -28,7 +28,7 @@
 
 ## Canonical Docs
 - `README.md`
-- `docs/architecture.md`
+- `docs/ja/harness-engineering.md`
 
 ## Non-Goals
 - 長い運用メモの再掲


### PR DESCRIPTION
## Summary
- Replace broken `docs/architecture.md` reference in `examples/ja/ail-repo-improvement-loop.md` with the existing `docs/ja/harness-engineering.md`.

Closes #52

## Test plan
- [x] `npm run verify` passes