### PR TITLE
fix: detect cross-locale filename collision in examples (#50)

### DIFF
--- a/scripts/lib/content-entries.ts
+++ b/scripts/lib/content-entries.ts
@@ -37,12 +37,12 @@ export type ContentEntry = LegacyContentEntry | FamilyContentEntry
 
 export interface ContentEntryWarningHook {
   code: 'W_SOURCE_CONFLICT_FILENAME'
-  policy: 'family-over-legacy'
+  policy: 'family-over-legacy' | 'cross-locale-last-wins'
   source: ContentSource
   target: string
   message: string
-  winnerKind: 'family'
-  loserKind: 'legacy'
+  winnerKind: 'legacy' | 'family'
+  loserKind: 'legacy' | 'family'
   winnerPath: string
   loserPath: string
 }
@@ -102,6 +102,25 @@ function isFamilyPreferred(
   incoming: ContentEntry,
 ): boolean {
   return current.entryKind === 'legacy' && incoming.entryKind === 'family'
+}
+
+function createCrossLocaleConflictHook(
+  source: ContentSource,
+  relativeName: string,
+  winnerPath: string,
+  loserPath: string,
+): ContentEntryWarningHook {
+  return {
+    code: 'W_SOURCE_CONFLICT_FILENAME',
+    policy: 'cross-locale-last-wins',
+    source,
+    target: relativeName,
+    message: `cross-locale-last-wins policy applied for "${relativeName}"`,
+    winnerKind: 'legacy',
+    loserKind: 'legacy',
+    winnerPath,
+    loserPath,
+  }
 }
 
 function createFamilyConflictHook(
@@ -170,6 +189,17 @@ function mergeEntriesByPolicy(sourceEntries: ContentEntry[]): {
       )
     }
 
+    // Same-kind fall-through: both legacy → cross-locale (or same-source) collision.
+    if (existing.entryKind === 'legacy' && entry.entryKind === 'legacy') {
+      warningHooks.push(
+        createCrossLocaleConflictHook(
+          entry.source,
+          entry.relativeName,
+          entry.fullPath,    // winner: later entry
+          existing.fullPath, // loser: overwritten entry
+        ),
+      )
+    }
     // Preserve prior behavior: later entries win when the entry type is the same.
     merged.set(entry.relativeName, entry)
   }

--- a/tests/content-entries.test.ts
+++ b/tests/content-entries.test.ts
@@ -198,6 +198,48 @@ describe('content entries', () => {
     expect(entry?.entryKind).toBe('family')
   })
 
+  it('emits cross-locale-last-wins warning when ja/foo.md and en/foo.md collide', () => {
+    const root = createTempDir('mantra-content-entries-cross-locale-')
+    tempDirs.push(root)
+
+    const examplesJa = path.join(root, 'examples', 'ja')
+    const examplesEn = path.join(root, 'examples', 'en')
+    fs.mkdirSync(examplesJa, { recursive: true })
+    fs.mkdirSync(examplesEn, { recursive: true })
+    fs.writeFileSync(path.join(examplesJa, 'collision.md'), '# JA', 'utf8')
+    fs.writeFileSync(path.join(examplesEn, 'collision.md'), '# EN', 'utf8')
+
+    process.env.MANTRA_USER_CONTENT_ROOTS = root
+
+    const result = listContentEntries('examples')
+    const matching = result.entries.filter(e => e.relativeName === 'collision.md')
+    expect(matching).toHaveLength(1)
+    expect(result.warningHooks).toHaveLength(1)
+    expect(result.warningHooks[0]?.policy).toBe('cross-locale-last-wins')
+    expect(result.warningHooks[0]?.target).toBe('collision.md')
+    expect(result.warningHooks[0]?.code).toBe('W_SOURCE_CONFLICT_FILENAME')
+  })
+
+  it('alphabetical last locale wins in cross-locale collision', () => {
+    const root = createTempDir('mantra-content-entries-cross-locale-order-')
+    tempDirs.push(root)
+
+    const examplesJa = path.join(root, 'examples', 'ja')
+    const examplesEn = path.join(root, 'examples', 'en')
+    fs.mkdirSync(examplesJa, { recursive: true })
+    fs.mkdirSync(examplesEn, { recursive: true })
+    fs.writeFileSync(path.join(examplesJa, 'collision.md'), '# JA', 'utf8')
+    fs.writeFileSync(path.join(examplesEn, 'collision.md'), '# EN', 'utf8')
+
+    process.env.MANTRA_USER_CONTENT_ROOTS = root
+
+    const result = listContentEntries('examples')
+    // sortedDirectoryNames returns ['en', 'ja'] alphabetically, so en is scanned first
+    // then ja overwrites → winner is ja, loser is en
+    expect(result.warningHooks[0]?.winnerPath).toBe(path.join(examplesJa, 'collision.md'))
+    expect(result.warningHooks[0]?.loserPath).toBe(path.join(examplesEn, 'collision.md'))
+  })
+
   it('returns both root-level and locale subdirectory entries', () => {
     const root = createTempDir('mantra-content-entries-locale-compat-')
     tempDirs.push(root)


### PR DESCRIPTION
## Summary
- `mergeEntriesByPolicy` now emits a `cross-locale-last-wins` warning hook when legacy entries with the same `relativeName` collide across locale subdirectories (e.g. `examples/ja/foo.md` vs `examples/en/foo.md`).
- Previously this was a silent data loss — one entry overwrote the other with no hook fired.
- Widens `ContentEntryWarningHook.policy` to a union of `'family-over-legacy' | 'cross-locale-last-wins'`. Downstream consumer (`setup-merge.ts::warningEventFromHook`) is unchanged — it reads the same fields.
- `relativeName` is intentionally NOT changed (no `ja/` prefix) so downstream sync output layouts are preserved.

Closes #50

## Test plan
- [x] `npm run verify` passes
- [x] `npx vitest run tests/content-entries.test.ts` — new cross-locale tests green, all existing tests still green