### PR TITLE
feat: configurable locale subdirs via sources.json (#53)

### DIFF
--- a/scripts/lib/content-entries.ts
+++ b/scripts/lib/content-entries.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { CliError } from './cli-telemetry'
-import { type ContentKind, type ContentSource, resolveContentSources } from './content-sources'
+import { type ContentKind, type ContentSource, resolveContentSources, getLocaleSubdirs } from './content-sources'
 import {
   composeSkillFamily,
   isSkillFamilyDirectoryName,
@@ -9,8 +9,6 @@ import {
   type LoadedSkillFamily,
 } from './skill-family'
 import { type SkillFamilyTarget } from './skill-family-schema'
-
-const LOCALE_SUBDIRS = new Set(['ja', 'en'])
 
 export type ContentEntryKind = 'legacy' | 'family'
 export type ContentTarget = SkillFamilyTarget
@@ -185,6 +183,7 @@ function listEntriesForSource(
   kind: ContentKind,
   target: ContentTarget,
 ): { entries: ContentEntry[]; warningHooks: ContentEntryWarningHook[] } {
+  const localeSubdirs = getLocaleSubdirs()
   const scanned: ContentEntry[] = []
 
   for (const name of sortedDirectoryNames(source.dir)) {
@@ -203,7 +202,7 @@ function listEntriesForSource(
     if (stat.isDirectory()) {
       if (isSkillFamilyDirectoryName(name)) {
         scanned.push(toFamilyEntry(source, fullPath, kind, target))
-      } else if (kind === 'examples' && LOCALE_SUBDIRS.has(name)) {
+      } else if (kind === 'examples' && localeSubdirs.has(name)) {
         for (const subName of sortedDirectoryNames(fullPath)) {
           const subFullPath = path.join(fullPath, subName)
           const subStat = fs.statSync(subFullPath)

--- a/scripts/lib/content-sources.ts
+++ b/scripts/lib/content-sources.ts
@@ -13,6 +13,7 @@ const SourcesFileSchema = z.object({
   rulesDirs: z.array(z.string()).optional().default([]),
   templatesDirs: z.array(z.string()).optional().default([]),
   examplesDirs: z.array(z.string()).optional().default([]),
+  locales: z.array(z.string()).optional().default(['ja', 'en']),
 })
 
 type SourcesFile = z.infer<typeof SourcesFileSchema>
@@ -225,4 +226,18 @@ export function countUserSources(kinds: ContentKind | ContentKind[]): number {
   }
 
   return seen.size
+}
+
+export function getLocaleSubdirs(): ReadonlySet<string> {
+  const sourcesFile = loadSourcesFile()
+  if (sourcesFile !== null) {
+    return new Set(sourcesFile.locales)
+  }
+
+  const envDirs = parseList(process.env.MANTRA_USER_LOCALES)
+  if (envDirs.length > 0) {
+    return new Set(envDirs)
+  }
+
+  return new Set(['ja', 'en'])
 }

--- a/tests/content-entries.test.ts
+++ b/tests/content-entries.test.ts
@@ -3,6 +3,7 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { listContentEntries } from '../scripts/lib/content-entries'
+import { __resetSourcesFileCache } from '../scripts/lib/content-sources'
 
 function createTempDir(prefix: string): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix))
@@ -29,13 +30,22 @@ function writeFamily(args: {
 describe('content entries', () => {
   const tempDirs: string[] = []
   const originalRootsEnv = process.env.MANTRA_USER_CONTENT_ROOTS
+  const originalLocalesEnv = process.env.MANTRA_USER_LOCALES
 
   beforeEach(() => {
     process.env.MANTRA_USER_CONTENT_ROOTS = ''
+    delete process.env.MANTRA_USER_LOCALES
+    __resetSourcesFileCache()
   })
 
   afterEach(() => {
     process.env.MANTRA_USER_CONTENT_ROOTS = originalRootsEnv
+    if (originalLocalesEnv === undefined) {
+      delete process.env.MANTRA_USER_LOCALES
+    } else {
+      process.env.MANTRA_USER_LOCALES = originalLocalesEnv
+    }
+    __resetSourcesFileCache()
     while (tempDirs.length > 0) {
       fs.rmSync(tempDirs.pop() as string, { recursive: true, force: true })
     }
@@ -221,5 +231,26 @@ describe('content entries', () => {
 
     expect(rootEntry).toBeDefined()
     expect(localeEntry).toBeDefined()
+  })
+
+  it('respects MANTRA_USER_LOCALES env var when sources.json absent', () => {
+    const root = createTempDir('mantra-content-entries-locale-env-')
+    tempDirs.push(root)
+
+    const examplesFr = path.join(root, 'examples', 'fr')
+    fs.mkdirSync(examplesFr, { recursive: true })
+    fs.writeFileSync(path.join(examplesFr, 'sample.md'), '# FR', 'utf8')
+
+    process.env.MANTRA_USER_CONTENT_ROOTS = root
+    process.env.MANTRA_USER_LOCALES = 'fr'
+    __resetSourcesFileCache()
+
+    const result = listContentEntries('examples')
+    const entry = result.entries.find(
+      item => item.source.dir === path.join(root, 'examples') && item.relativeName === 'sample.md',
+    )
+
+    expect(entry).toBeDefined()
+    expect(entry?.entryKind).toBe('legacy')
   })
 })


### PR DESCRIPTION
## Summary
- Add `locales` field to `sources.json` schema (defaults to `['ja', 'en']`).
- Add `MANTRA_USER_LOCALES` env var fallback (comma-separated), mirroring the existing `MANTRA_USER_CONTENT_ROOTS` pattern.
- Replace the hardcoded `LOCALE_SUBDIRS` constant in `content-entries.ts` with a call to the new `getLocaleSubdirs()` helper.
- Users can now add new locales (fr, zh, ko, …) without code changes.

Closes #53

## ⚠️ Merge order
This PR should be merged **AFTER** #50 (fix/issue-50-cross-locale-loss). Both touch `scripts/lib/content-entries.ts` at non-overlapping lines, but rebase is required once #50 lands.

## Test plan
- [x] `npm run verify` passes
- [x] `npx vitest run tests/content-entries.test.ts` — new env-var test green
- [x] `MANTRA_USER_LOCALES=fr npm run test:unit` passes