### PR TITLE
feat: P0-P4判定 UserPromptSubmit hook（Track D 段階1）

### DIFF
--- a/hooks/p-judge.sh
+++ b/hooks/p-judge.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# p-judge.sh — mantra P0-P4 判定 UserPromptSubmit hook
+#
+# rules/agents.md の P0-P4 ラダー（Immediate Agent Usage）をヒューリスティックに判定し、
+# 該当する場合のみ「[mantra] P判定: ...」をコンテキストに強制注入する。
+# プロンプト（貼り紙）ではなく hooks（信号機）でエージェント自動起動を促す機構化（Track D 段階1）。
+#
+# 入力: stdin に UserPromptSubmit の JSON（.prompt または .message にユーザープロンプト）
+# 出力: 該当あり → {"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"..."}}
+#       該当なし(P0) → 何も出力しない（静音）
+#
+# 判定バックエンドは MANTRA_PJUDGE_BACKEND で差し替え可能:
+#   heuristic (既定) … キーワード/ヒューリスティック
+#   haiku            … claude -p --model haiku に委譲（精度不足時の将来オプション）
+#
+# 設計方針: hook は絶対にプロンプト投入を壊さない。依存欠落・異常時は静かに exit 0。
+
+set -uo pipefail
+
+# jq が無ければ静かに諦める（プロンプトは通常通り通す）
+command -v jq >/dev/null 2>&1 || exit 0
+
+input=$(cat 2>/dev/null || true)
+[ -n "$input" ] || exit 0
+
+prompt=$(printf '%s' "$input" | jq -r '.prompt // .message // ""' 2>/dev/null || true)
+[ -n "$prompt" ] || exit 0
+
+# --- ヒューリスティック判定 ---------------------------------------------------
+# 小文字化して英日キーワードで走査。該当した P レベルの助言行を stdout に1行ずつ出す。
+judge_heuristic() {
+  local text
+  text=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+
+  # P3: 高リスクスコープ（security / auth / billing / migration / data-integrity）
+  if printf '%s' "$text" | grep -qiE 'security|auth(entication|orization)?|login|credential|password|secret|token|encrypt|billing|payment|invoice|subscription|migration|migrate|schema change|data integrity|セキュリティ|認証|認可|ログイン|パスワード|秘密鍵|暗号|課金|決済|請求|サブスク|マイグレーション|スキーマ変更|データ整合'; then
+    echo 'P3(高リスク) → security/auth/billing/migration/data-integrity を検知。mob-navigator で分解し、mob-critic + security-reviewer を必ず含める（FM-AGENT-CRITIC）'
+  fi
+
+  # P1: planner 条件（3+ステップ / 2+ファイル / 実装・非自明な判断）
+  if printf '%s' "$text" | grep -qiE 'implement|refactor|feature|build |rewrite|redesign|architecture|multiple files|across files|実装|リファクタ|機能追加|作って|設計|作り直|複数ファイル|横断|アーキ|移行|多段' \
+     || printf '%s' "$text" | grep -qiE '[3-9]\+? ?(steps|files|つ|個|箇所|ファイル|ステップ)'; then
+    echo 'P1 → 3+ステップ / 2+ファイル / 非自明な実装判断の可能性。planner を先に起動（複雑なら architect も）'
+  fi
+
+  # P4: code-reviewer 条件（非自明なコード変更 → 実装後にレビュー）
+  if printf '%s' "$text" | grep -qiE 'implement|refactor|feature|fix bug|バグ修正|実装|リファクタ|機能追加|修正|コード|関数|クラス|エンドポイント|api'; then
+    echo 'P4 → 非自明なコード変更。実装が終わったら code-reviewer を起動（docs-only の軽微編集は不要）'
+  fi
+}
+
+# haiku バックエンド（将来の差し替えポイント）。失敗時はヒューリスティックへフォールバック。
+judge_haiku() {
+  command -v claude >/dev/null 2>&1 || { judge_heuristic "$1"; return; }
+  local out
+  out=$(printf '%s' "$1" | claude -p --model haiku \
+    'あなたは mantra の P0-P4 判定器。次のユーザープロンプトに対し rules/agents.md の P0-P4 ラダーで該当する助言を、"Pn → 理由 起動対象" 形式で1行ずつ出力。該当なしなら空文字。プロンプト:' \
+    2>/dev/null || true)
+  if [ -n "$out" ]; then printf '%s\n' "$out"; else judge_heuristic "$1"; fi
+}
+
+case "${MANTRA_PJUDGE_BACKEND:-heuristic}" in
+  haiku) verdict=$(judge_haiku "$prompt") ;;
+  *)     verdict=$(judge_heuristic "$prompt") ;;
+esac
+
+# 該当なし = P0（静音）
+[ -n "$verdict" ] || exit 0
+
+# 「[mantra] P判定:」ヘッダ + 各助言行を additionalContext として注入
+message=$(printf '[mantra] P判定（rules/agents.md ラダー・自動注入）:\n%s' \
+  "$(printf '%s' "$verdict" | sed 's/^/- /')")
+
+jq -cn --arg ctx "$message" \
+  '{hookSpecificOutput:{hookEventName:"UserPromptSubmit",additionalContext:$ctx}}'

--- a/tests/contracts/p-judge-hook-contract.test.ts
+++ b/tests/contracts/p-judge-hook-contract.test.ts
@@ -1,0 +1,66 @@
+import { execFileSync } from 'node:child_process'
+import * as path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const HOOK = path.resolve(__dirname, '..', '..', 'hooks', 'p-judge.sh')
+
+interface HookOutput {
+  hookSpecificOutput?: {
+    hookEventName?: string
+    additionalContext?: string
+  }
+}
+
+function runHook(inputJson: string): { stdout: string; parsed: HookOutput | null } {
+  const stdout = execFileSync('bash', [HOOK], {
+    input: inputJson,
+    encoding: 'utf8',
+  }).trim()
+  const parsed = stdout.length > 0 ? (JSON.parse(stdout) as HookOutput) : null
+  return { stdout, parsed }
+}
+
+function contextOf(inputJson: string): string {
+  const { parsed } = runHook(inputJson)
+  expect(parsed?.hookSpecificOutput?.hookEventName).toBe('UserPromptSubmit')
+  return parsed?.hookSpecificOutput?.additionalContext ?? ''
+}
+
+describe('p-judge hook contract (P0-P4 injection)', () => {
+  it('P0: 静音 — 軽微な docs-only 編集では何も注入しない', () => {
+    const { stdout } = runHook(JSON.stringify({ prompt: 'READMEのタイポ直して' }))
+    expect(stdout).toBe('')
+  })
+
+  it('P1: 実装/複数ファイルで planner 起動を注入する', () => {
+    const ctx = contextOf(JSON.stringify({ prompt: 'ユーザー一覧画面を実装して。複数ファイルにまたがる' }))
+    expect(ctx).toContain('[mantra] P判定')
+    expect(ctx).toContain('P1')
+    expect(ctx).toContain('planner')
+  })
+
+  it('P3: 認証/課金/マイグレーション等の高リスクで mob-critic + security-reviewer を必須注入する', () => {
+    const ctx = contextOf(JSON.stringify({ prompt: 'ログイン認証まわりのトークン検証を修正して' }))
+    expect(ctx).toContain('P3')
+    expect(ctx).toContain('security-reviewer')
+    expect(ctx).toContain('mob-critic')
+  })
+
+  it('P4: 非自明なコード変更で code-reviewer を注入する', () => {
+    const ctx = contextOf(JSON.stringify({ prompt: 'この関数のバグ修正して' }))
+    expect(ctx).toContain('P4')
+    expect(ctx).toContain('code-reviewer')
+  })
+
+  it('.message フィールドでも .prompt と同様に判定する（後方互換）', () => {
+    const ctx = contextOf(JSON.stringify({ message: '決済のマイグレーションを実装' }))
+    expect(ctx).toContain('P3')
+    expect(ctx).toContain('P1')
+  })
+
+  it('空入力・空プロンプトでも壊れず静音で通す', () => {
+    expect(runHook('').stdout).toBe('')
+    expect(runHook(JSON.stringify({ prompt: '' })).stdout).toBe('')
+    expect(runHook('not-json-at-all').stdout).toBe('')
+  })
+})


### PR DESCRIPTION
## 背景

mantra の P0-P4 エージェント自動起動ルール（`rules/agents.md`）が定義済みなのに、エージェント側が判定・自動起動を怠る問題が過去2回指摘されている。対策を「CLAUDE.md への強調追記」（プロンプト強化）ではなく、hooks による機構的強制に切り替える（AI活用改善計画 Track D 段階1）。

## 変更

- **`hooks/p-judge.sh`**: UserPromptSubmit hook。stdin の `.prompt`（`.message` も後方互換）を読み、`rules/agents.md` のラダーをヒューリスティック判定して該当時のみ `[mantra] P判定: ...` を `additionalContext` に注入する。
  - P1 → planner / P3 → mob-critic + security-reviewer（FM-AGENT-CRITIC）/ P4 → code-reviewer
  - P0（軽微 docs 等）は静音
  - `MANTRA_PJUDGE_BACKEND=haiku` で判定を `claude -p --model haiku` に差し替え可能な構造（既定は heuristic）
  - jq 欠落・入力欠落・非JSON でも静かに `exit 0`（プロンプト投入を絶対に壊さない）
- **`tests/contracts/p-judge-hook-contract.test.ts`**: P0/P1/P3/P4・後方互換・異常系の契約テスト（6件）

## スコープ外

- グローバル `~/.claude/settings.json` の UserPromptSubmit への登録（全セッション発火）は git 管理外のためローカルに直接適用済み。既存 myak-query hook と並列共存。
- 段階2（PreToolUse でのエージェント未起動時ブロック）は段階1の運用を見てから。

## テスト

- `npx vitest run tests/contracts/p-judge-hook-contract.test.ts` → 6 passed
- `npm run test:unit` → 19 files / 140 passed（既存テスト非破壊）
- 手動: P0/P1/P3/P4 各サンプル JSON を流して注入内容を確認

## 受け入れ条件

- [x] 新規セッションでユーザー指示なしに P判定がコンテキストに現れる（サンプル JSON で確認）
- [x] 既存 hooks（危険コマンド block / git push 時 Zed / myak-query 注入）と競合しない
- [x] 通常フロー（fetch→branch→test→PR）で PR 化